### PR TITLE
Add nix flake (derivation + direnv)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,94 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1691421349,
+        "narHash": "sha256-RRJyX0CUrs4uW4gMhd/X4rcDG8PTgaaCQM5rXEJOx6g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "011567f35433879aae5024fc6ec53f2a0568a6c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,66 @@
+{
+  description = "Ragnar Window Manager";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      libs = with pkgs; [
+        fontconfig
+      ] ++ (with pkgs.xorg; [
+        libX11
+        libXft
+        libXcursor
+        libXcomposite
+      ]);
+
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = with pkgs; [
+          gnumake
+          gcc
+          glibc
+        ] ++ libs;
+      };
+
+      packages.ragnarwm = pkgs.stdenv.mkDerivation {
+        name = "ragnarwm";
+        src = ./.;
+
+        makeFlags = [
+          "CC=${pkgs.stdenv.cc}/bin/cc"
+        ];
+
+        buildInputs = libs;
+        hardeningDisable = [ "format" "fortify" ];
+
+        installPhase = ''
+          runHook preInstall
+
+          mkdir -p $out/bin
+          mkdir -p $out/share/applications
+          mkdir -p $out/share/xessions
+
+	      cp -f ragnar $out/bin
+	      cp -f ragnar.desktop $out/share/applications
+	      cp -f ragnar.desktop $out/share/xsessions
+	      cp -f ragnarstart $out/bin
+	      chmod 755 $out/bin/ragnar
+
+          runHook postInstall
+        '';
+      };
+
+      packages.default = self.packages.${system}.ragnarwm;
+    });
+}


### PR DESCRIPTION
As `PKGBUILD`, the `flake.nix` & `flake.lock`  file provide a way to build a [nix derivation](https://nixos.org/manual/nix/stable/language/derivations.html) (package) for [NixOS](https://nixos.org/).
I've made a [Pull Request](https://github.com/NixOS/nixpkgs/pull/247909) for `ragnarwm` within the official [nixpkgs repository](https://github.com/NixOS/nixpkgs) along side this pull request.

Build ragner using nix
```sh
nix build .
```

> Note: [Flakes](https://nixos.wiki/wiki/Flakes) are still an "experimental feature" of nix despite its wide use.

Moreover, this `flake.nix` provides a [shell](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html) with the dependencies required to compile this project.
This means that in any Linux distributions, windows WSL or even OSX, and other system supporting the [nix package manager](https://nixos.org/download) you use use it to pull the dependencies and enters in a development shell with everything setup for you.

Entering the shell
```sh
nix develop
# do casual stuff
make
```

This can integrate with [direnv](https://direnv.net/) to automatically loads thoses dependencies went you enter the directory, once enabled.
direnv can integrate within multiples shells (bash, zsh, fish, tcsh, ...)

How to setup automatic direnv in project:
```sh
echo "use flake" | tee -a .envrc
direnv allow
```