### PR TITLE
Makefile portability improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,30 @@
-CC 			= cc
-CFLAGS 	= -O3 -ffast-math -Wall -Wextra -pedantic
-LIBS 		= -lxcb -lxcb-keysyms -lxcb-icccm -lxcb-cursor -lxcb-randr -lxcb-composite -lxcb-ewmh -lX11 -lX11-xcb -lGL -lm -lconfig
-SRC 		= ./src/*.c ./src/ipc/*.c
-BIN 		= ragnar
+CC = cc
+CFLAGS = -O3 -ffast-math -Wall -Wextra -pedantic
+CFLAGS += -isystem api/include
 
-all:
+LDLIBS = -lxcb -lxcb-keysyms -lxcb-icccm -lxcb-cursor -lxcb-randr -lxcb-composite -lxcb-ewmh -lX11 -lX11-xcb -lGL -lm -lconfig
+
+SRC = ./src/*.c ./src/ipc/*.c
+BIN = ragnar
+
+RAGNAR_API = api/lib/ragnar.a
+
+PREFIX = /usr
+BINDIR = $(PREFIX)/bin
+
+.PHONY: all
+all: $(RAGNAR_API)
 	mkdir -p ./bin
-	${CC} -o bin/${BIN} ${SRC} ${LIBS} ${CFLAGS}
+	$(CC) -o bin/$(BIN) $(CFLAGS) $(SRC) $(LDLIBS)
+
+$(RAGNAR_API):
+	$(MAKE) -C api
 
 SOURCE_DIR := ./cfg/ 
 DEST_DIR := $(HOME)/.config/ragnarwm
 CONFIG_FILE := $(DEST_DIR)/ragnar.cfg
 
+.PHONY: config
 config:
 	@if [ ! -f "$(CONFIG_FILE)" ]; then \
 		echo "Config file does not exist. Copying default config..."; \
@@ -21,16 +34,18 @@ config:
 		echo "Config file already exists. Skipping copy."; \
 	fi
 
+.PHONY: install
 install: 
-	sudo cp -f bin/${BIN} /usr/bin
-	sudo cp -f ragnar.desktop /usr/share/xsessions/
-	sudo cp -f ragnarstart /usr/bin
-	sudo chmod 755 /usr/bin/ragnar
+	install -Dm755 bin/$(BIN) -t $(BINDIR)
+	install -Dm755 ragnarstart -t $(BINDIR)
+	cp -f ragnar.desktop $(PREFIX)/share/xsessions/
 
+.PHONY: clean
 clean:
-	rm -f bin/*
+	$(RM) bin/*
 
+.PHONY: uninstall
 uninstall:
-	sudo rm -f /usr/bin/ragnar
-	sudo rm -f /usr/share/xsessions/ragnar.desktop
-	sudo rm -f /usr/bin/ragnarstart
+	$(RM) $(BINDIR)/ragnar
+	$(RM) $(PREFIX)/share/xsessions/ragnar.desktop
+	$(RM) $(BINDIR)/ragnarstart

--- a/flake.lock
+++ b/flake.lock
@@ -5,30 +5,31 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
-        "id": "flake-utils",
-        "type": "indirect"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691421349,
-        "narHash": "sha256-RRJyX0CUrs4uW4gMhd/X4rcDG8PTgaaCQM5rXEJOx6g=",
+        "lastModified": 1723703277,
+        "narHash": "sha256-nk0RaUB5f68BwtXAYy3WAjqFhVKqIl9Z89RGycTa2vk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "011567f35433879aae5024fc6ec53f2a0568a6c4",
+        "rev": "8b908192e64224420e2d59dfd9b2e4309e154c5d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -36,8 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -52,39 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,26 +2,26 @@
   description = "Ragnar Window Manager";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-    utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    ...
-  }:
+  outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
 
       libs = with pkgs; [
-        fontconfig
+        libGL
+        mesa
+        libconfig
       ] ++ (with pkgs.xorg; [
         libX11
-        libXft
-        libXcursor
-        libXcomposite
+        libxcb
+        xcbutil
+        xcbutilwm
+        xorgproto
+        xcb-util-cursor
+        xcbutilkeysyms
       ]);
 
     in {
@@ -29,7 +29,6 @@
         packages = with pkgs; [
           gnumake
           gcc
-          glibc
         ] ++ libs;
       };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -32,35 +32,5 @@
           glibc
         ] ++ libs;
       };
-
-      packages.ragnarwm = pkgs.stdenv.mkDerivation {
-        name = "ragnarwm";
-        src = ./.;
-
-        makeFlags = [
-          "CC=${pkgs.stdenv.cc}/bin/cc"
-        ];
-
-        buildInputs = libs;
-        hardeningDisable = [ "format" "fortify" ];
-
-        installPhase = ''
-          runHook preInstall
-
-          mkdir -p $out/bin
-          mkdir -p $out/share/applications
-          mkdir -p $out/share/xessions
-
-	      cp -f ragnar $out/bin
-	      cp -f ragnar.desktop $out/share/applications
-	      cp -f ragnar.desktop $out/share/xsessions
-	      cp -f ragnarstart $out/bin
-	      chmod 755 $out/bin/ragnar
-
-          runHook postInstall
-        '';
-      };
-
-      packages.default = self.packages.${system}.ragnarwm;
     });
 }


### PR DESCRIPTION
Addresses to following:

- #55:
  - Automatically Build the `api/lib/ragnar.a` lib from the main Makefile by calling `make -C`
  - Add `-isystem api/include` to `CFLAGS`, in order resolve  `<ragnar/api.h>` without system-wide installation
  - Remove erroneous use of `sudo`in Makefile,
    no further changes are requires as `install.sh` already calls `sudo make install`
  - Add a `PREFIX` and `BINDIR` variables that point to the installation directories

- Features other refactoring of the Makefile:
  - using `$(RM)` builtin instead of `rm -f`
  - use `install` command for binaries
  - add missing markers for `PHONY` rules
  - replaced use of `${...}` in favor of `$(...)`
  - renamed `LIBS` to standard `LDLIBS` variable

- Update to `flake.nix`:
  - feature latest version dependencies
  - remove the obsolete `ragnar` package, as it is ported to nixpkgs

This set of changes will improve the packaging process.
In nixpkgs, it will allow removing the multiples patches done to the Makefile