### PR TITLE
Add Keyboard Layout Config Option and Fix Memory Leaks

### DIFF
--- a/cfg/ragnar.cfg
+++ b/cfg/ragnar.cfg
@@ -186,8 +186,6 @@ keyboard_layout = "us";
 
 #=========== Key bindings ===========
 
-keyboard_layout = "de";
-
 keybinds = (
   {
     mod = "Super";

--- a/cfg/ragnar.cfg
+++ b/cfg/ragnar.cfg
@@ -180,8 +180,11 @@ should_log_to_file = false;
 # that can be allocated
 max_scratchpads = 10;
 
-# --------------------------------
- #=========== Key bindings ===========
+# 
+# Specifies the layout that is used for ragnar
+keyboard_layout = "us";
+
+#=========== Key bindings ===========
 
 keyboard_layout = "de";
 

--- a/cfg/ragnar.cfg
+++ b/cfg/ragnar.cfg
@@ -1,9 +1,9 @@
 
-# ██████   █████   ██████  ███    ██  █████  ██████       ██████  ██████  ███    ██ ███████ ██  ██████  
-# ██   ██ ██   ██ ██       ████   ██ ██   ██ ██   ██     ██      ██    ██ ████   ██ ██      ██ ██       
-# ██████  ███████ ██   ███ ██ ██  ██ ███████ ██████      ██      ██    ██ ██ ██  ██ █████   ██ ██   ███ 
-# ██   ██ ██   ██ ██    ██ ██  ██ ██ ██   ██ ██   ██     ██      ██    ██ ██  ██ ██ ██      ██ ██    ██ 
-# ██   ██ ██   ██  ██████  ██   ████ ██   ██ ██   ██      ██████  ██████  ██   ████ ██      ██  ██████  
+# ██████   █████   ██████  ███    ██  █████  ██████       ██████  ██████  ███    ██ ███████ ██  ██████
+# ██   ██ ██   ██ ██       ████   ██ ██   ██ ██   ██     ██      ██    ██ ████   ██ ██      ██ ██
+# ██████  ███████ ██   ███ ██ ██  ██ ███████ ██████      ██      ██    ██ ██ ██  ██ █████   ██ ██   ███
+# ██   ██ ██   ██ ██    ██ ██  ██ ██ ██   ██ ██   ██     ██      ██    ██ ██  ██ ██ ██      ██ ██    ██
+# ██   ██ ██   ██  ██████  ██   ████ ██   ██ ██   ██      ██████  ██████  ██   ████ ██      ██  ██████
 
 # Options:
 # ----------------------
@@ -34,138 +34,138 @@
 #   - "right_ptr"
 #   - "xterm"
 # ----------------------
-# NOTE: For all key options, see: 
+# NOTE: For all key options, see:
 # https://github.com/cococry/ragnar/blob/main/src/structs.h#L89
 #
-# NOTE: For all function options, see: 
+# NOTE: For all function options, see:
 # https://github.com/cococry/ragnar/blob/main/src/structs.h#L18
 # ----------------------
 #
 
-# Specifies the width of the border around client 
+# Specifies the width of the border around client
 # windows
 win_border_width = 3;
-# Specifies the color of the border around client 
+# Specifies the color of the border around client
 # windows
 win_border_color = 0xa1a1a1;
-# Specifies the color of the border around 
+# Specifies the color of the border around
 # selected/focused client windows
 win_border_color_selected = 0xffffff;
 
-# Specifies the main modifier key that is 
+# Specifies the main modifier key that is
 # used to execute window manager shortcuts
 mod_key = "Super";
-# Specifies the modifier key that is used 
+# Specifies the modifier key that is used
 # to interact with clients windows
 win_mod = "Super";
 
-# Specfies the mouse button that needs to be 
+# Specifies the mouse button that needs to be
 # held in order to move client windows
 move_button = "LeftMouse";
-# Specfies the mouse button that needs to be 
+# Specifies the mouse button that needs to be
 # held in order to resize client windows
 resize_button = "RightMouse";
 
-# Specifies the desktop index that is initially 
+# Specifies the desktop index that is initially
 # selected on every monitor
 initial_desktop = 0;
-# Specfies the maximum number of allocated virtual
+# Specifies the maximum number of allocated virtual
 # desktops
 num_desktops = 9;
 # Specifies the name of every virtual desktop
 # in order.
 desktop_names = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
-# Specifies whether or not server-side window 
+# Specifies whether or not server-side window
 # decorations should be enabled.
 use_decoration = false;
-# Specifies whether or not server-side titlebars 
-# should be shown on startup. (Ignored when 
+# Specifies whether or not server-side titlebars
+# should be shown on startup. (Ignored when
 # use_decoration is set to false.)
 show_titlebars_init = true;
 
-# Specifies the height (in pixels) of the 
+# Specifies the height (in pixels) of the
 # titlebar of client windows.
 titlebar_height = 30
-# Specifies the color of titlebars of 
+# Specifies the color of titlebars of
 # client windows
 titlebar_color = 0xffffff;
 
-# Specifies the color of the font that is used 
+# Specifies the color of the font that is used
 # across the window manager's UI
 font_color = 0xff0000ff;
-# Specifies the path to the font file to use as 
+# Specifies the path to the font file to use as
 # the window manager's font
 font_path = "/usr/share/fonts/TTF/JetBrainsMonoNerdFont-Bold.ttf";
 
-# Specifies the area that the master window takes 
-# up in master-slave layouts initially. 
+# Specifies the area that the master window takes
+# up in master-slave layouts initially.
 # (in 0.0-1.0 %)
 layout_master_area = 0.5
 # Specifies the minimum area that master windows
-# need to take up in master-slave layouts 
+# need to take up in master-slave layouts
 # (in 0.0-1.0 %)
 layout_master_area_min = 0.1
 # Specifies the maximum area that master windows
-# can take up in master-slave layouts 
+# can take up in master-slave layouts
 # (in 0.0-1.0 %)
 layout_master_area_max = 0.9
-# Specifies the amount that the master area changes/steps 
+# Specifies the amount that the master area changes/steps
 # when it is decreased/increased.
 # (in 0.0-1.0 %)
 layout_master_area_step = 0.1
 
-# Specifies the amount that areas of windows 
+# Specifies the amount that areas of windows
 # within layouts change when they are increased/decreased
 # (in px)
 layout_size_step = 100.0;
-# Specifies the minimum area that windows within 
-# layouts need to take up 
+# Specifies the minimum area that windows within
+# layouts need to take up
 # (in px)
 layout_size_min = 150.0;
 
-# Specifies the amount that windows are moved 
+# Specifies the amount that windows are moved
 # by when using 'move' shortcuts for floating windows
 # (in px)
 key_win_move_step = 100.0;
 
-# Specifies the initial gap between windows 
+# Specifies the initial gap between windows
 # within layouts (in px)
 win_layout_gap = 5;
 # Specifies the maximum gap that windows within
 # layouts can have around each other (in px)
 win_layout_gap_max = 150;
-# Specifies the amount that the gap between 
-# non-floating windows changes when it's 
+# Specifies the amount that the gap between
+# non-floating windows changes when it's
 # decreased/increased (in px)
 # (in px)
 win_layout_gap_step = 5;
 
-# Specifies the layout that is initially used 
+# Specifies the layout that is initially used
 # for every virtual desktop
 initial_layout = "LayoutTiledMaster";
 
 # Advanced Configuration
 # --------------------------------
 
-# Specifies the framerate at which motion notify 
-# events are captured. This is used to streamline 
+# Specifies the framerate at which motion notify
+# events are captured. This is used to streamline
 # performance. Especially on high polling rate mouses,
-# lag can be very noticable when not throtteling motion 
+# lag can be very noticeable when not throtteling motion
 # notify events.
-motion_notify_debounce_fps = 60; 
+motion_notify_debounce_fps = 60;
 
-# Specifies the maximum number of 'strut'-window that 
-# the window manager can capture. Struts are information 
-# about window positions and sizes that are used to correctly 
+# Specifies the maximum number of 'strut'-window that
+# the window manager can capture. Struts are information
+# about window positions and sizes that are used to correctly
 # establish window layouts with bars or other status windows.
 max_struts = 8;
 
-# Specifies if decoration that is rendered with OpenGL should 
+# Specifies if decoration that is rendered with OpenGL should
 # use Vsync
 gl_vsync = false;
 
-# Specifies the cursor image to use for the root window 
+# Specifies the cursor image to use for the root window
 cursor_image = "arrow";
 
 # Specifies whether or not to log messages
@@ -176,13 +176,14 @@ log_messages = false;
 # to the log file
 should_log_to_file = false;
 
-# Specifies the maximum number of scratchpads 
+# Specifies the maximum number of scratchpads
 # that can be allocated
 max_scratchpads = 10;
 
 # --------------------------------
+ #=========== Key bindings ===========
 
-# =========== Key bindings ===========
+keyboard_layout = "de";
 
 keybinds = (
   {
@@ -504,4 +505,3 @@ keybinds = (
     i = 2
   },
 );
-

--- a/ragnarstart
+++ b/ragnarstart
@@ -1,4 +1,3 @@
-setxkbmap de &
 boron &
 nitrogen --restore &
 xrandr --output eDP1 --primary --auto --output eDP1 --left-of HDMI2 --auto

--- a/src/structs.h
+++ b/src/structs.h
@@ -423,6 +423,8 @@ typedef struct {
   bool shouldlogtofile;
 
   char* cursorimage;
+
+  const char* keyboard_layout;
 } config_data_t;
 
 typedef struct {


### PR DESCRIPTION
So, I added the ability to configure the keyboard layout in the `ragnar.cfg` file. Before, if you wanted to change the layout, you had to modify the `ragnarstart` script and recompile it yourself, which wasn't ideal for people installing via AUR. This PR makes it easier for users to set their preferred layout without needing to compile from source. I also fixed some memory leaks that were hanging around.

#### Why This Change
Previously, changing the keyboard layout was kind of a pain because you needed to run the `setxkbmap` command every time you log in.

#### What I Did
1. **Added support for configuring the keyboard layout in `ragnar.cfg`**:
   - You can add `keyboard_layout = "us";` or any other layout to the config, and it'll set it on startup. It uses `setxkbmap` under the hood.
   - If you don't set it or if the layout is invalid, it logs an error and won't change anything.

2. **Fixed some memory leaks**:
   - I went through and cleaned up some spots where memory wasn’t being freed properly. This should help with stability and performance, especially during longer sessions.

