### PR TITLE
Fix trailing comma in default config (ragnar.cfg)

### DIFF
--- a/cfg/ragnar.cfg
+++ b/cfg/ragnar.cfg
@@ -563,5 +563,5 @@ keybinds = (
     key = "KeyAudioMute";
     do  = "runcmd";
     cmd = "amixer sset Master toggle";
-  },
+  }
 );


### PR DESCRIPTION
cfg/ragnar.cfg line 566 had a trailing comma before );

Changed:

  },
);

to:

  }
);

The trailing comma caused RagnarWM config parsing failures at startup.